### PR TITLE
Update launchSettings.json

### DIFF
--- a/src/CleanAspire.ClientApp/Properties/launchSettings.json
+++ b/src/CleanAspire.ClientApp/Properties/launchSettings.json
@@ -4,8 +4,7 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "launchBrowser": true,      
       "applicationUrl": "http://localhost:5180",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -14,8 +13,7 @@
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "inspectUri": "{wsProtocol}://{url.hostname}:{url.port}/_framework/debug/ws-proxy?browser={browserInspectUri}",
+      "launchBrowser": true,      
       "applicationUrl": "https://localhost:7123;http://localhost:5180",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"


### PR DESCRIPTION

{url.hostname} and {url.port} might be dynamic during runtime, but Aspire might need explicit values.
Identify the exact hostname and port Aspire uses, and hardcode them if necessary - just remove as this PR does.