### PR TITLE
Add PicklistAutocomplete component

### DIFF
--- a/src/CleanAspire.ClientApp/Components/Autocompletes/PicklistAutocomplete.razor.cs
+++ b/src/CleanAspire.ClientApp/Components/Autocompletes/PicklistAutocomplete.razor.cs
@@ -1,0 +1,35 @@
+﻿
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+namespace CleanAspire.ClientApp.Components.Autocompletes;
+
+public class PicklistAutocomplete<T> : MudAutocomplete<string>
+{
+    public PicklistAutocomplete()
+    {
+        MaxItems = 50;
+        SearchFunc = SearchFunc_;
+        Dense = true;
+        ResetValueOnEmptyText = true;
+    }
+
+    [Parameter]
+    public PicklistType Picklist { get; set; }
+
+    public Dictionary<PicklistType, string[]> Data => PicklistDataSource.Data;
+
+    private Task<IEnumerable<string>> SearchFunc_(string? value, CancellationToken cancellation = default)
+    {
+        if (!Data.ContainsKey(Picklist))
+            return Task.FromResult(Enumerable.Empty<string>());
+
+        var list = Data[Picklist];
+
+        if (string.IsNullOrEmpty(value))
+            return Task.FromResult(list.AsEnumerable());
+
+        return Task.FromResult(list.Where(x =>
+            x.Contains(value, StringComparison.InvariantCultureIgnoreCase)));
+    }
+}

--- a/src/CleanAspire.ClientApp/Components/Autocompletes/PicklistDataSource.cs
+++ b/src/CleanAspire.ClientApp/Components/Autocompletes/PicklistDataSource.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace CleanAspire.ClientApp.Components.Autocompletes;
+
+public static class PicklistDataSource
+{
+    public static readonly Dictionary<PicklistType, string[]> Data = new Dictionary<PicklistType, string[]>
+    {
+        { PicklistType.UOM, new[] { "EA", "PCS", "KG", "M", "L", "BOX", "PKG" } },
+        { PicklistType.Currency, new[] { "USD", "EUR", "GBP", "CNY", "JPY", "AUD", "CAD" } }
+    };
+}
+public enum PicklistType
+{
+    UOM,
+    Currency
+}

--- a/src/CleanAspire.ClientApp/Layout/Appbar.razor
+++ b/src/CleanAspire.ClientApp/Layout/Appbar.razor
@@ -1,9 +1,9 @@
 ﻿<MudAppBar Elevation="0" Fixed="false">
     <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start" />
-    <MudText Typo="Typo.h6"> @L["BlazorPocket Application"]</MudText>
+    <MudText Typo="Typo.h6"> @L[AppSettings.AppName]</MudText>
     <MudSpacer />
-    <MudTooltip Delay="1000" Text="https://github.com/neozhu/BlazorPocketApp.git">
-        <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://github.com/neozhu/BlazorPocketApp.git" Target="_blank" />
+    <MudTooltip Delay="1000" Text="https://github.com/neozhu/cleanaspire.git">
+        <MudIconButton Icon="@Icons.Custom.Brands.GitHub" Color="Color.Inherit" Href="https://github.com/neozhu/cleanaspire.git" Target="_blank" />
     </MudTooltip>
     <MudTooltip Delay="1000" Text="@(LayoutService.IsDarkMode ? L["Light mode"]: L["Dark mode"])">
     <MudToggleIconButton Toggled="@LayoutService.IsDarkMode" Icon="@Icons.Material.TwoTone.WbSunny"

--- a/src/CleanAspire.ClientApp/Layout/MainLayout.razor
+++ b/src/CleanAspire.ClientApp/Layout/MainLayout.razor
@@ -1,6 +1,6 @@
 ﻿@inherits LayoutComponentBase
 
-<PageTitle>@L["Blazor WPA"]</PageTitle>
+<PageTitle>@L[AppSettings.AppName]</PageTitle>
 
 <MudRTLProvider RightToLeft="@LayoutService.IsRTL">
     <MudThemeProvider @ref="@_mudThemeProvider" Theme="@LayoutService.CurrentTheme" IsDarkMode="@LayoutService.IsDarkMode" IsDarkModeChanged="@LayoutService.SetDarkMode" />

--- a/src/CleanAspire.ClientApp/Pages/Products/Components/NewProductDialog.razor
+++ b/src/CleanAspire.ClientApp/Pages/Products/Components/NewProductDialog.razor
@@ -1,4 +1,5 @@
-﻿
+﻿@using CleanAspire.ClientApp.Components.Autocompletes
+
 <MudDialog>
     <DialogContent>
         <MudForm @ref="editForm" @bind-IsValid="@success" @bind-Errors="@errors">
@@ -22,10 +23,10 @@
                     </MudEnumSelect>
                 </MudItem>
                 <MudItem xs="12" md="6">
-                    <MudTextField @bind-Value="model.Uom" For="@(() => model.Uom)"
+                    <PicklistAutocomplete T="string" PickList="PicklistType.UOM" @bind-Value="model.Uom" For="@(() => model.Uom)"
                                   Label="@L["UOM"]" Placeholder="@L["Uom"]"
                                   Required="false" RequiredError="@L["Uom is required"]">
-                    </MudTextField>
+                    </PicklistAutocomplete>
                 </MudItem>
                 <MudItem xs="12" md="6">
                     <MudNumericField @bind-Value="model.Price" For="@(() => model.Price)"
@@ -34,10 +35,10 @@
                     </MudNumericField>
                 </MudItem>
                 <MudItem xs="12" md="6">
-                    <MudTextField @bind-Value="model.Currency" For="@(() => model.Currency)"
+                    <PicklistAutocomplete T="string" PickList="PicklistType.Currency" @bind-Value="model.Currency" For="@(() => model.Currency)"
                                   Label="@L["Currency"]" Placeholder="@L["Currency"]"
                                   Required="true" RequiredError="@L["Currency is required"]">
-                    </MudTextField>
+                    </PicklistAutocomplete>
                 </MudItem>
                 <MudItem xs="12" md="12">
                     <MudTextField @bind-Value="model.Description" For="@(() => model.Description)"

--- a/src/CleanAspire.ClientApp/Pages/Products/Edit.razor
+++ b/src/CleanAspire.ClientApp/Pages/Products/Edit.razor
@@ -30,7 +30,7 @@
                     </MudEnumSelect>
                 </MudItem>
                 <MudItem xs="12" md="6">
-                    <PicklistAutocomplete T="string" PickList="UOM" @bind-Value="model.Uom" For="@(() => model.Uom)"
+                    <PicklistAutocomplete T="string" PickList="PicklistType.UOM" @bind-Value="model.Uom" For="@(() => model.Uom)"
                                   Label="@L["UOM"]" Placeholder="@L["Uom"]"
                                   Required="false" RequiredError="@L["Uom is required"]">
                     </PicklistAutocomplete>
@@ -42,7 +42,7 @@
                     </MudNumericField>
                 </MudItem>
                 <MudItem xs="12" md="6">
-                    <PicklistAutocomplete T="string" PickList="Currency" @bind-Value="model.Currency" For="@(() => model.Currency)"
+                    <PicklistAutocomplete T="string" PickList="PicklistType.Currency" @bind-Value="model.Currency" For="@(() => model.Currency)"
                                   Label="@L["Currency"]" Placeholder="@L["Currency"]"
                                   Required="true" RequiredError="@L["Currency is required"]">
                     </PicklistAutocomplete>

--- a/src/CleanAspire.ClientApp/Pages/Products/Edit.razor
+++ b/src/CleanAspire.ClientApp/Pages/Products/Edit.razor
@@ -1,4 +1,5 @@
 ﻿@page "/products/edit/{Id}"
+@using CleanAspire.ClientApp.Components.Autocompletes
 @using CleanAspire.ClientApp.Components.Breadcrumbs
 @inherits MudComponentBase
 
@@ -29,10 +30,10 @@
                     </MudEnumSelect>
                 </MudItem>
                 <MudItem xs="12" md="6">
-                    <MudTextField @bind-Value="model.Uom" For="@(() => model.Uom)"
+                    <PicklistAutocomplete T="string" PickList="UOM" @bind-Value="model.Uom" For="@(() => model.Uom)"
                                   Label="@L["UOM"]" Placeholder="@L["Uom"]"
                                   Required="false" RequiredError="@L["Uom is required"]">
-                    </MudTextField>
+                    </PicklistAutocomplete>
                 </MudItem>
                 <MudItem xs="12" md="6">
                     <MudNumericField @bind-Value="model.Price" For="@(() => model.Price)"
@@ -41,10 +42,10 @@
                     </MudNumericField>
                 </MudItem>
                 <MudItem xs="12" md="6">
-                    <MudTextField @bind-Value="model.Currency" For="@(() => model.Currency)"
+                    <PicklistAutocomplete T="string" PickList="Currency" @bind-Value="model.Currency" For="@(() => model.Currency)"
                                   Label="@L["Currency"]" Placeholder="@L["Currency"]"
                                   Required="true" RequiredError="@L["Currency is required"]">
-                    </MudTextField>
+                    </PicklistAutocomplete>
                 </MudItem>
                 <MudItem xs="12" md="12">
                     <MudTextField @bind-Value="model.Description" For="@(() => model.Description)"


### PR DESCRIPTION
### PR Description
This PR introduces a reusable `PicklistAutocomplete<T>` component to simplify selecting values from predefined lists (e.g., UOM, Currency) using autocomplete functionality. By leveraging a `PicklistType` enum, any attempt to reference a non-existent picklist key will result in compile-time errors, ensuring data consistency between the UI component and the data source.

### Usage
In a Razor component, use `PicklistAutocomplete` as follows:

```razor
<PicklistAutocomplete T="string" Picklist="PicklistType.UOM" @bind-Value="model.Uom" For="@(() => model.Uom)"
                      Label="@L["UOM"]" Placeholder="@L["Uom"]"
                      Required="false" RequiredError="@L["Uom is required"]">
</PicklistAutocomplete>
```
![image](https://github.com/user-attachments/assets/9300103f-4429-4ce5-898f-06cf9767c9b9)

By using the strongly-typed `PicklistType` enum, the system prevents invalid values at compile time, ensuring that only existing picklist entries are used.