### PR TITLE
Fix code scanning alert no. 5: Uncontrolled format string

### DIFF
--- a/src/CleanAspire.Infrastructure/Services/UploadService.cs
+++ b/src/CleanAspire.Infrastructure/Services/UploadService.cs
@@ -78,6 +78,7 @@ public class UploadService : IUploadService
         if (!File.Exists(path))
             return path;
 
+        path = path.Replace("{", "{{").Replace("}", "}}");
         if (Path.HasExtension(path))
             return GetNextFilename(path.Insert(path.LastIndexOf(Path.GetExtension(path)), NumberPattern));
 


### PR DESCRIPTION
Fixes [https://github.com/neozhu/cleanaspire/security/code-scanning/5](https://github.com/neozhu/cleanaspire/security/code-scanning/5)

To fix the uncontrolled format string issue, we need to ensure that the `pattern` used in `string.Format` is safe and does not contain any unexpected format specifiers. One way to achieve this is by validating or sanitizing the `path` before using it to construct the `pattern`. Additionally, we can use a safer method to construct the `pattern` string.

The best way to fix the problem without changing existing functionality is to use a predefined format string and ensure that the `path` does not contain any format specifiers. We can achieve this by escaping any curly braces in the `path` before constructing the `pattern`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
