### PR TITLE
Integrate CleanAspire Docker Deployment with Traefik Reverse Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,14 @@ https://github.com/neozhu/cleanaspire/issues/34
 
 ### OpenAPI documentation
 - https://apiservice.blazorserver.com/scalar/v1
+- https://cleanapi.blazors.app:8443/scalar/v1
+
+### Demo site
+- https://cleanweb.blazors.app:8443/
 
 ### Blazor WebAssembly Standalone PWA
 - https://standalone.blazorserver.com/
+- https://standalone.blazors.app:8443/
 
 
 ### Here is an example of a docker-compose.yml file for a local Docker deployment:
@@ -97,8 +102,9 @@ https://github.com/neozhu/cleanaspire/issues/34
 ```yml
 version: '3.8'
 services:
-  apiservice:
-    image: blazordevlab/cleanaspire-api:0.0.69
+  cleanapi:
+    image: blazordevlab/cleanaspire-api:0.0.70
+    container_name: cleanapi
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
       - AllowedHosts=*
@@ -107,37 +113,69 @@ services:
       - ASPNETCORE_HTTPS_PORTS=443
       - DatabaseSettings__DBProvider=sqlite
       - DatabaseSettings__ConnectionString=Data Source=CleanAspireDb.db
-      - AllowedCorsOrigins=https://cleanaspire.blazorserver.com,https://standalone.blazorserver.com,https://localhost:7114
-      - Authentication__Google__ClientId=<your client id>
-      - Authentication__Google__ClientSecret=<your client secret>
-      - SendGrid__ApiKey=<your API key>
-      - SendGrid__DefaultFromEmail=<your email>
+      - ClientBaseUrl=https://web.cleanaspire.blazors.app:8443
+      - AllowedCorsOrigins=https://cleanweb.blazors.app:8443,https://standalone.blazors.app:8443
+      - SendGrid__ApiKey=<your-api-key>
+      - SendGrid__DefaultFromEmail=noreply@blazorserver.com
+      - Authentication__Google__ClientId=<your-client-id>
+      - Authentication__Google__ClientSecret=<your-secret-key>
       - Webpushr__Token=<your-webpushr-token>
-      - Webpushr__ApiKey=<your-webpushr-api-keys>
+      - Webpushr__ApiKey=<your-webpushr-api-key>
       - Webpushr__PublicKey=<your-webpushr-public-key>
-    ports:
-      - "8019:80"
-      - "8018:443"
-
-  blazorweb:
-    image: blazordevlab/cleanaspire-webapp:0.0.69
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.cleanapi-secure.entrypoints=https"
+      - "traefik.http.routers.cleanapi-secure.rule=Host(`cleanapi.blazors.app`)"
+      - "traefik.http.routers.cleanapi-secure.tls=true"
+      - "traefik.http.routers.cleanapi-secure.service=cleanapi"
+      - "traefik.http.services.cleanapi.loadbalancer.server.port=443"
+      - "traefik.http.services.cleanapi.loadbalancer.server.scheme=https"
+      - "traefik.docker.network=proxy"
+    networks:
+      proxy:
+    security_opt:
+      - no-new-privileges:true
+  cleanweb:
+    image: blazordevlab/cleanaspire-webapp:0.0.70
+    container_name: cleanweb
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
       - AllowedHosts=*
       - ASPNETCORE_URLS=http://+:80;https://+:443
       - ASPNETCORE_HTTP_PORTS=80
       - ASPNETCORE_HTTPS_PORTS=443
-    ports:
-      - "8015:80"
-      - "8014:443"
-
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.cleanweb-secure.entrypoints=https"
+      - "traefik.http.routers.cleanweb-secure.rule=Host(`cleanweb.blazors.app`)"
+      - "traefik.http.routers.cleanweb-secure.tls=true"
+      - "traefik.http.routers.cleanweb-secure.service=cleanweb"
+      - "traefik.http.services.cleanweb.loadbalancer.server.port=443"
+      - "traefik.http.services.cleanweb.loadbalancer.server.scheme=https"
+      - "traefik.docker.network=proxy"
+    networks:
+      proxy:
+    security_opt:
+      - no-new-privileges:true
   standalone:
-    image: blazordevlab/cleanaspire-standalone:0.0.69
-    ports:
-      - "8020:80"
-      - "8021:443"
-
-
+    container_name: standalone
+    image: blazordevlab/cleanaspire-standalone:0.0.70
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.standalone-secure.entrypoints=https"
+      - "traefik.http.routers.standalone-secure.rule=Host(`standalone.blazors.app`)"
+      - "traefik.http.routers.standalone-secure.tls=true"
+      - "traefik.http.routers.standalone-secure.service=standalone"
+      - "traefik.http.services.standalone.loadbalancer.server.port=443"
+      - "traefik.http.services.standalone.loadbalancer.server.scheme=https"
+      - "traefik.docker.network=proxy"
+    networks:
+      proxy:
+    security_opt:
+      - no-new-privileges:true
+networks:
+  proxy:
+    external: true
 
 ```
 

--- a/src/CleanAspire.Api/appsettings.json
+++ b/src/CleanAspire.Api/appsettings.json
@@ -6,7 +6,7 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedCorsOrigins": "https://localhost:7341,https://localhost:7123,https://localhost:7114",
+  "AllowedCorsOrigins": "https://localhost:7341,https://localhost:7123,https://localhost:7114;https://api.cleanaspire.blazors.app:8443",
   "ClientBaseUrl": "https://localhost:7114",
   "DatabaseSettings": {
     "DBProvider": "sqlite",

--- a/src/CleanAspire.ClientApp/wwwroot/appsettings.json
+++ b/src/CleanAspire.ClientApp/wwwroot/appsettings.json
@@ -8,6 +8,6 @@
   "ClientAppSettings": {
     "AppName": "Blazor Aspire",
     "Version": "v0.0.69",
-    "ServiceBaseUrl": "https://apiservice"
+    "ServiceBaseUrl": "https://cleanapi.blazors.app:8443"
   }
 }

--- a/src/CleanAspire.ClientApp/wwwroot/appsettings.json
+++ b/src/CleanAspire.ClientApp/wwwroot/appsettings.json
@@ -7,7 +7,7 @@
   },
   "ClientAppSettings": {
     "AppName": "Blazor Aspire",
-    "Version": "v0.0.69",
+    "Version": "v0.0.70",
     "ServiceBaseUrl": "https://cleanapi.blazors.app:8443"
   }
 }

--- a/src/CleanAspire.ClientApp/wwwroot/appsettings.json
+++ b/src/CleanAspire.ClientApp/wwwroot/appsettings.json
@@ -8,6 +8,6 @@
   "ClientAppSettings": {
     "AppName": "Blazor Aspire",
     "Version": "v0.0.69",
-    "ServiceBaseUrl": "https://apiservice.blazorserver.com"
+    "ServiceBaseUrl": "https://apiservice"
   }
 }

--- a/src/CleanAspire.WebApp/appsettings.json
+++ b/src/CleanAspire.WebApp/appsettings.json
@@ -8,7 +8,7 @@
   "AllowedHosts": "*",
   "ClientAppSettings": {
     "AppName": "Blazor Aspire",
-    "Version": "v0.0.69",
+    "Version": "v0.0.70",
     "ServiceBaseUrl": "https://cleanapi.blazors.app:8443"
   }
 }

--- a/src/CleanAspire.WebApp/appsettings.json
+++ b/src/CleanAspire.WebApp/appsettings.json
@@ -9,6 +9,6 @@
   "ClientAppSettings": {
     "AppName": "Blazor Aspire",
     "Version": "v0.0.69",
-    "ServiceBaseUrl": "https://api.cleanaspire.blazors.app:8443"
+    "ServiceBaseUrl": "https://cleanapi.blazors.app:8443"
   }
 }

--- a/src/CleanAspire.WebApp/appsettings.json
+++ b/src/CleanAspire.WebApp/appsettings.json
@@ -9,6 +9,6 @@
   "ClientAppSettings": {
     "AppName": "Blazor Aspire",
     "Version": "v0.0.69",
-    "ServiceBaseUrl": "https://apiservice.blazorserver.com"
+    "ServiceBaseUrl": "https://apiservice"
   }
 }

--- a/src/CleanAspire.WebApp/appsettings.json
+++ b/src/CleanAspire.WebApp/appsettings.json
@@ -9,6 +9,6 @@
   "ClientAppSettings": {
     "AppName": "Blazor Aspire",
     "Version": "v0.0.69",
-    "ServiceBaseUrl": "https://apiservice"
+    "ServiceBaseUrl": "https://api.cleanaspire.blazors.app:8443"
   }
 }


### PR DESCRIPTION
**Description:**  
This PR introduces changes that enable the CleanAspire Docker deployment to be fully integrated with Traefik for reverse proxying. The key changes include:

- **Docker Compose Updates:**  
  - Added necessary Traefik labels to the CleanAspire service for automatic routing.
  - Configured environment variables and network settings to ensure seamless communication between the service and Traefik.

- **Traefik Configuration:**  
  - Set up router and middleware rules specific to CleanAspire to handle routing, redirection, and load balancing.
  - Ensured proper domain and path matching so that incoming requests are correctly directed to the CleanAspire container.

- **Documentation:**  
  - Updated the deployment guides and README to reflect the changes, including instructions on configuring Traefik with CleanAspire.
  - Provided examples for running the Docker containers with Traefik integration.

```yaml
version: '3.8'
services:
  cleanapi:
    image: blazordevlab/cleanaspire-api:0.0.70
    container_name: cleanapi
    environment:
      - ASPNETCORE_ENVIRONMENT=Development
      - AllowedHosts=*
      - ASPNETCORE_URLS=http://+:80;https://+:443
      - ASPNETCORE_HTTP_PORTS=80
      - ASPNETCORE_HTTPS_PORTS=443
      - DatabaseSettings__DBProvider=sqlite
      - DatabaseSettings__ConnectionString=Data Source=CleanAspireDb.db
      - ClientBaseUrl=https://web.cleanaspire.blazors.app:8443
      - AllowedCorsOrigins=https://cleanweb.blazors.app:8443,https://standalone.blazors.app:8443
      - SendGrid__ApiKey=<your-api-key>
      - SendGrid__DefaultFromEmail=noreply@blazorserver.com
      - Authentication__Google__ClientId=<your-client-id>
      - Authentication__Google__ClientSecret=<your-secret-key>
      - Webpushr__Token=<your-webpushr-token>
      - Webpushr__ApiKey=<your-webpushr-api-key>
      - Webpushr__PublicKey=<your-webpushr-public-key>
    labels:
      - "traefik.enable=true"
      - "traefik.http.routers.cleanapi-secure.entrypoints=https"
      - "traefik.http.routers.cleanapi-secure.rule=Host(`cleanapi.blazors.app`)"
      - "traefik.http.routers.cleanapi-secure.tls=true"
      - "traefik.http.routers.cleanapi-secure.service=cleanapi"
      - "traefik.http.services.cleanapi.loadbalancer.server.port=443"
      - "traefik.http.services.cleanapi.loadbalancer.server.scheme=https"
      - "traefik.docker.network=proxy"
    networks:
      proxy:
    security_opt:
      - no-new-privileges:true
  cleanweb:
    image: blazordevlab/cleanaspire-webapp:0.0.70
    container_name: cleanweb
    environment:
      - ASPNETCORE_ENVIRONMENT=Production
      - AllowedHosts=*
      - ASPNETCORE_URLS=http://+:80;https://+:443
      - ASPNETCORE_HTTP_PORTS=80
      - ASPNETCORE_HTTPS_PORTS=443
    labels:
      - "traefik.enable=true"
      - "traefik.http.routers.cleanweb-secure.entrypoints=https"
      - "traefik.http.routers.cleanweb-secure.rule=Host(`cleanweb.blazors.app`)"
      - "traefik.http.routers.cleanweb-secure.tls=true"
      - "traefik.http.routers.cleanweb-secure.service=cleanweb"
      - "traefik.http.services.cleanweb.loadbalancer.server.port=443"
      - "traefik.http.services.cleanweb.loadbalancer.server.scheme=https"
      - "traefik.docker.network=proxy"
    networks:
      proxy:
    security_opt:
      - no-new-privileges:true
  standalone:
    container_name: standalone
    image: blazordevlab/cleanaspire-standalone:0.0.70
    labels:
      - "traefik.enable=true"
      - "traefik.http.routers.standalone-secure.entrypoints=https"
      - "traefik.http.routers.standalone-secure.rule=Host(`standalone.blazors.app`)"
      - "traefik.http.routers.standalone-secure.tls=true"
      - "traefik.http.routers.standalone-secure.service=standalone"
      - "traefik.http.services.standalone.loadbalancer.server.port=443"
      - "traefik.http.services.standalone.loadbalancer.server.scheme=https"
      - "traefik.docker.network=proxy"
    networks:
      proxy:
    security_opt:
      - no-new-privileges:true
networks:
  proxy:
    external: true





```
