### PR TITLE
Integrate MinIO for File Uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ https://github.com/neozhu/cleanaspire/issues/34
 version: '3.8'
 services:
   cleanapi:
-    image: blazordevlab/cleanaspire-api:0.0.70
+    image: blazordevlab/cleanaspire-api:0.0.73
     container_name: cleanapi
     environment:
       - ASPNETCORE_ENVIRONMENT=Development
@@ -122,6 +122,10 @@ services:
       - Webpushr__Token=<your-webpushr-token>
       - Webpushr__ApiKey=<your-webpushr-api-key>
       - Webpushr__PublicKey=<your-webpushr-public-key>
+      - Minio__Endpoint=<your-minio-server>
+      - Minio__AccessKey=<your-minio-key>
+      - Minio__SecretKey=<your-minio-secret>
+      - Minio__BucketName=demo
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.cleanapi-secure.entrypoints=https"
@@ -136,7 +140,7 @@ services:
     security_opt:
       - no-new-privileges:true
   cleanweb:
-    image: blazordevlab/cleanaspire-webapp:0.0.70
+    image: blazordevlab/cleanaspire-webapp:0.0.73
     container_name: cleanweb
     environment:
       - ASPNETCORE_ENVIRONMENT=Production
@@ -159,7 +163,7 @@ services:
       - no-new-privileges:true
   standalone:
     container_name: standalone
-    image: blazordevlab/cleanaspire-standalone:0.0.70
+    image: blazordevlab/cleanaspire-standalone:0.0.73
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.standalone-secure.entrypoints=https"

--- a/src/CleanAspire.Api/CleanAspire.Api.csproj
+++ b/src/CleanAspire.Api/CleanAspire.Api.csproj
@@ -11,7 +11,7 @@
         <OpenApiDocumentsDirectory>$(MSBuildProjectDirectory)</OpenApiDocumentsDirectory>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Bogus" Version="35.6.1" />
+        <PackageReference Include="Bogus" Version="35.6.2" />
         <PackageReference Include="Google.Apis.Auth" Version="1.69.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.2" />
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
@@ -24,9 +24,9 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="9.0.2" />
-        <PackageReference Include="Scalar.AspNetCore" Version="2.0.12" />
+        <PackageReference Include="Scalar.AspNetCore" Version="2.0.18" />
         <PackageReference Include="Scrutor" Version="6.0.1" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
+       
         <PackageReference Include="StrongGrid" Version="0.110.0" />
     </ItemGroup>
     <ItemGroup>

--- a/src/CleanAspire.Api/appsettings.json
+++ b/src/CleanAspire.Api/appsettings.json
@@ -32,6 +32,12 @@
       "ClientSecret": "your-client-secret"
     }
   },
+  "Minio": {
+    "Endpoint": "minio.blazorserver.com",
+    "AccessKey": "your-access-key",
+    "SecretKey": "your-secret-key",
+    "BucketName": "aspire"
+  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Debug",

--- a/src/CleanAspire.Application/CleanAspire.Application.csproj
+++ b/src/CleanAspire.Application/CleanAspire.Application.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+      <PackageReference Include="SixLabors.ImageSharp" Version="3.1.6" />
       <PackageReference Include="CsvHelper" Version="33.0.1" />
       <PackageReference Include="FluentValidation" Version="12.0.0-preview1" />
       <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0-preview1" />

--- a/src/CleanAspire.Application/Common/Interfaces/IUploadService.cs
+++ b/src/CleanAspire.Application/Common/Interfaces/IUploadService.cs
@@ -2,22 +2,34 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.ComponentModel;
+using SixLabors.ImageSharp.Processing;
 
 namespace CleanAspire.Application.Common.Interfaces;
 
 public interface IUploadService
 {
     Task<string> UploadAsync(UploadRequest request);
-    void Remove(string filename);
+    Task RemoveAsync(string filename);
 }
-public record UploadRequest(
-    string FileName,
-    UploadType UploadType,
-    byte[] Data,
-    bool Overwrite = false,
-    string? Extension = null,
-    string? Folder = null
-);
+public class UploadRequest
+{
+    public UploadRequest(string fileName, UploadType uploadType, byte[] data, bool overwrite = false, string? folder = null, ResizeOptions? resizeOptions = null)
+    {
+        FileName = fileName;
+        UploadType = uploadType;
+        Data = data;
+        Overwrite = overwrite;
+        Folder = folder;
+        ResizeOptions = resizeOptions;
+    }
+    public string FileName { get; set; }
+    public string? Extension { get; set; }
+    public UploadType UploadType { get; set; }
+    public bool Overwrite { get; set; }
+    public byte[] Data { get; set; }
+    public string? Folder { get; set; }
+    public ResizeOptions? ResizeOptions { get; set; }
+}
 public enum UploadType : byte
 {
     [Description(@"Products")] Product,

--- a/src/CleanAspire.ClientApp/wwwroot/appsettings.json
+++ b/src/CleanAspire.ClientApp/wwwroot/appsettings.json
@@ -8,6 +8,6 @@
   "ClientAppSettings": {
     "AppName": "Blazor Aspire",
     "Version": "v0.0.73",
-    "ServiceBaseUrl": "https://cleanapi.blazors.app:8443"
+    "ServiceBaseUrl": "https://cleanaspireservice.blazorserver.com"
   }
 }

--- a/src/CleanAspire.ClientApp/wwwroot/appsettings.json
+++ b/src/CleanAspire.ClientApp/wwwroot/appsettings.json
@@ -7,7 +7,7 @@
   },
   "ClientAppSettings": {
     "AppName": "Blazor Aspire",
-    "Version": "v0.0.70",
+    "Version": "v0.0.73",
     "ServiceBaseUrl": "https://cleanapi.blazors.app:8443"
   }
 }

--- a/src/CleanAspire.Infrastructure/CleanAspire.Infrastructure.csproj
+++ b/src/CleanAspire.Infrastructure/CleanAspire.Infrastructure.csproj
@@ -18,6 +18,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.2" />
         <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.2" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.2" />
+        <PackageReference Include="Minio" Version="6.0.4" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.2" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.2" />

--- a/src/CleanAspire.Infrastructure/Configurations/MinioOptions.cs
+++ b/src/CleanAspire.Infrastructure/Configurations/MinioOptions.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CleanAspire.Infrastructure.Configurations;
+public class MinioOptions
+{
+    public const string Key = "Minio";
+    public string Endpoint { get; set; } = "minio.blazorserver.com";
+    public string AccessKey { get; set; } = string.Empty;
+    public string SecretKey { get; set; } = string.Empty;
+    public string BucketName { get; set; } = "demo";
+}

--- a/src/CleanAspire.Infrastructure/DependencyInjection.cs
+++ b/src/CleanAspire.Infrastructure/DependencyInjection.cs
@@ -38,10 +38,12 @@ public static class DependencyInjection
     public static IServiceCollection AddInfrastructure(this IServiceCollection services,
         IConfiguration configuration)
     {
+        services.Configure<MinioOptions>(configuration.GetSection(MinioOptions.Key))
+            .AddSingleton(s => s.GetRequiredService<IOptions<MinioOptions>>().Value);
         services
             .AddDatabase(configuration)
             .AddFusionCacheService()
-            .AddScoped<IUploadService, UploadService>();
+            .AddScoped<IUploadService, MinioUploadService>();
  
 
         return services;

--- a/src/CleanAspire.Infrastructure/Services/FileUploadService.cs
+++ b/src/CleanAspire.Infrastructure/Services/FileUploadService.cs
@@ -14,7 +14,7 @@ namespace CleanAspire.Infrastructure.Services;
 /// <summary>
 /// Service for uploading files.
 /// </summary>
-public class UploadService : IUploadService
+public class FileUploadService : IUploadService
 {
     private static readonly string NumberPattern = " ({0})";
 
@@ -60,13 +60,14 @@ public class UploadService : IUploadService
     /// remove file
     /// </summary>
     /// <param name="filename"></param>
-    public void Remove(string filename)
+    public Task RemoveAsync(string filename)
     {
         var removefile = Path.Combine(Directory.GetCurrentDirectory(), filename);
         if (File.Exists(removefile))
         {
             File.Delete(removefile);
         }
+        return Task.CompletedTask;
     }
     /// <summary>
     /// Gets the next available filename based on the given path.

--- a/src/CleanAspire.Infrastructure/Services/MinioUploadService.cs
+++ b/src/CleanAspire.Infrastructure/Services/MinioUploadService.cs
@@ -1,0 +1,125 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CleanAspire.Application.Common.Interfaces;
+using CleanAspire.Infrastructure.Configurations;
+using Microsoft.AspNetCore.StaticFiles;
+using Minio;
+using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Processing;
+using Minio.DataModel.Args;
+
+namespace CleanAspire.Infrastructure.Services;
+public class MinioUploadService : IUploadService
+{
+    private readonly IMinioClient _minioClient;
+    private readonly string _bucketName;
+    private readonly string _endpoint;
+    public MinioUploadService(MinioOptions options)
+    {
+        var opt = options;
+        _endpoint = opt.Endpoint;
+        _minioClient = new MinioClient()
+                            .WithEndpoint(_endpoint)
+                            .WithCredentials(opt.AccessKey, opt.SecretKey)
+                            .WithSSL()
+                            .Build();
+        _bucketName = opt.BucketName;
+    }
+
+    public async Task<string> UploadAsync(UploadRequest request)
+    {
+        // Use FileExtensionContentTypeProvider to determine the MIME type.
+        var provider = new FileExtensionContentTypeProvider();
+        if (!provider.TryGetContentType(request.FileName, out var contentType))
+        {
+            contentType = "application/octet-stream";
+        }
+
+        // Define common bitmap image extensions (not including vector formats like SVG).
+        var bitmapImageExtensions = new[] { ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp" };
+        var ext = Path.GetExtension(request.FileName).ToLowerInvariant();
+
+        // If ResizeOptions is provided and the file is a bitmap image, process the image.
+        if (request.ResizeOptions != null && Array.Exists(bitmapImageExtensions, e => e.Equals(ext, StringComparison.OrdinalIgnoreCase)))
+        {
+            using var inputStream = new MemoryStream(request.Data);
+            using var outputStream = new MemoryStream();
+            using var image = Image.Load(inputStream);
+            image.Mutate(x => x.Resize(request.ResizeOptions));
+            // Convert the image to PNG format.
+            image.Save(outputStream, new PngEncoder());
+            request.Data = outputStream.ToArray();
+            contentType = "image/png";
+        }
+
+        // Ensure the bucket exists.
+        bool bucketExists = await _minioClient.BucketExistsAsync(new BucketExistsArgs().WithBucket(_bucketName));
+        if (!bucketExists)
+        {
+            await _minioClient.MakeBucketAsync(new MakeBucketArgs().WithBucket(_bucketName));
+        }
+
+        // Build folder path based on UploadType and optional Folder property.
+        string folderPath = $"{request.UploadType.ToString()}";
+        if (!string.IsNullOrWhiteSpace(request.Folder))
+        {
+            folderPath = $"{folderPath}/{request.Folder.Trim('/')}";
+        }
+
+        // Construct the object name including the folder path.
+        string objectName = $"{folderPath}/{request.FileName}";
+
+        using (var stream = new MemoryStream(request.Data))
+        {
+            await _minioClient.PutObjectAsync(new PutObjectArgs()
+                .WithBucket(_bucketName)
+                .WithObject(objectName)
+                .WithStreamData(stream)
+                .WithObjectSize(stream.Length)
+                .WithContentType(contentType)
+            );
+        }
+
+        // Return the URL constructed using the configured Endpoint.
+        return $"https://{_endpoint}/{_bucketName}/{objectName}";
+    }
+    public async Task RemoveAsync(string filename)
+    {
+        // Remove the "https://" or "http://" prefix from the URL and extract the bucket and object name.
+        Uri fileUri = new Uri(filename);
+
+        // Ensure the URL is well-formed and can be parsed
+        if (!fileUri.IsAbsoluteUri)
+            throw new ArgumentException("Invalid URL format.");
+
+        // Extract the bucket from the path portion of the URL
+        string[] pathParts = fileUri.AbsolutePath.TrimStart('/').Split('/', 2);
+        if (pathParts.Length < 2)
+            throw new ArgumentException("URL format must be 'https://<endpoint>/<bucket>/<object>'.");
+
+        string bucket = pathParts[0];
+        string objectName = pathParts[1];
+
+        try
+        {
+            // Proceed to remove the object from the correct bucket
+            await _minioClient.RemoveObjectAsync(new RemoveObjectArgs()
+                 .WithBucket(bucket)
+                 .WithObject(objectName));
+        }
+        catch (Exception ex)
+        {
+            throw new Exception("Error deleting object", ex);
+        }
+    }
+
+
+}

--- a/src/CleanAspire.WebApp/CleanAspire.WebApp.csproj
+++ b/src/CleanAspire.WebApp/CleanAspire.WebApp.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.2" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CleanAspire.WebApp/appsettings.json
+++ b/src/CleanAspire.WebApp/appsettings.json
@@ -9,6 +9,6 @@
   "ClientAppSettings": {
     "AppName": "Blazor Aspire",
     "Version": "v0.0.73",
-    "ServiceBaseUrl": "https://cleanapi.blazors.app:8443"
+    "ServiceBaseUrl": "https://cleanaspireservice.blazorserver.com"
   }
 }

--- a/src/CleanAspire.WebApp/appsettings.json
+++ b/src/CleanAspire.WebApp/appsettings.json
@@ -8,7 +8,7 @@
   "AllowedHosts": "*",
   "ClientAppSettings": {
     "AppName": "Blazor Aspire",
-    "Version": "v0.0.70",
+    "Version": "v0.0.73",
     "ServiceBaseUrl": "https://cleanapi.blazors.app:8443"
   }
 }


### PR DESCRIPTION
This PR introduces the integration of MinIO for file uploads into the application. It includes the creation of a new service MinioUploadService which is responsible for managing file uploads to MinIO storage.

"Minio": {
  "Endpoint": "minio.blazors.app:8443",
  "AccessKey": "your-access-key",
  "SecretKey": "your-secret-key",
  "BucketName": "files"
},