### PR TITLE
Use stable .NET 10 images and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## CleanAspire - .NET 9 Minimal API + Blazor WebAssembly PWA Template with Aspire Support 
+## CleanAspire - .NET 10 Minimal API + Blazor WebAssembly PWA Template with Aspire Support
 [![.NET](https://github.com/neozhu/cleanaspire/actions/workflows/dotnet.yml/badge.svg)](https://github.com/neozhu/cleanaspire/actions/workflows/dotnet.yml)
 [![CodeQL](https://github.com/neozhu/cleanaspire/actions/workflows/github-code-scanning/codeql/badge.svg)](https://github.com/neozhu/cleanaspire/actions/workflows/github-code-scanning/codeql)
 [![Build and Push Docker Image](https://github.com/neozhu/cleanaspire/actions/workflows/docker.yml/badge.svg)](https://github.com/neozhu/cleanaspire/actions/workflows/docker.yml)
@@ -7,7 +7,7 @@
 
 ### 🚀 Overview  
 
-**CleanAspire** is a cutting-edge, open-source template built on **.NET 9**, designed to accelerate the development of **lightweight**, **fast**, and **simple** Blazor WebAssembly or Progressive Web Applications (PWA). It seamlessly integrates **Minimal APIs**, **Aspire**, and **Scalar** for modern API documentation.  
+**CleanAspire** is a cutting-edge, open-source template built on **.NET 10** (and still compatible with **.NET 9** projects), designed to accelerate the development of **lightweight**, **fast**, and **simple** Blazor WebAssembly or Progressive Web Applications (PWA). It seamlessly integrates **Minimal APIs**, **Aspire**, and **Scalar** for modern API documentation.
 
 With a focus on **Clean Architecture** and **extreme code simplicity**, CleanAspire provides developers with the tools to create responsive and maintainable web applications with minimal effort. The template also supports **Microsoft.Kiota** to simplify API client generation, ensuring consistency and productivity in every project.  
 
@@ -37,8 +37,8 @@ By incorporating robust offline capabilities, CleanAspire empowers developers to
    - Fully integrated with **Aspire** for efficient application hosting and configuration.  
    - Simplifies the setup process while providing a robust foundation for lightweight applications.  
 
-2. **Fast and Minimal .NET 9 Minimal APIs**  
-   - Uses the latest .NET 9 features to create high-performance and efficient APIs.  
+2. **Fast and Minimal .NET 10 Minimal APIs**
+   - Uses the latest .NET 10 features to create high-performance and efficient APIs.
    - Includes **Scalar** for modern and concise OpenAPI documentation, replacing traditional Swagger tools.  
 
 3. **Designed for Simplicity and Speed**  
@@ -82,7 +82,7 @@ https://github.com/neozhu/cleanaspire/issues/34
 - **Lightweight and Fast:** Designed to create high-performance, minimal Blazor WebAssembly or PWA projects.  
 - **Effortless Development:** Extreme simplicity in code makes it easy to start quickly and scale effectively.  
 - **Advanced API Integration:** Automate client-side API generation with Microsoft.Kiota for faster results.  
-- **Future-Ready Architecture:** Leverages the latest .NET 9 capabilities and Aspire hosting for modern web applications.
+- **Future-Ready Architecture:** Leverages the latest .NET 10 capabilities and Aspire hosting for modern web applications.
 - 
 
 ### OpenAPI documentation

--- a/src/CleanAspire.Api/Dockerfile
+++ b/src/CleanAspire.Api/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the API Application
-FROM mcr.microsoft.com/dotnet/sdk:10.0-rc.1 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 COPY ["src/CleanAspire.Api/CleanAspire.Api.csproj", "src/CleanAspire.Api/"]
@@ -18,7 +18,7 @@ WORKDIR /src/src/CleanAspire.Api
 RUN dotnet publish "./CleanAspire.Api.csproj" -c Release -o /app/publish
 
 # Stage 2: Create the runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-rc.1 AS runtime
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
 WORKDIR /app
 
 # Copy the build output from the previous stage

--- a/src/CleanAspire.ClientApp/Dockerfile
+++ b/src/CleanAspire.ClientApp/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Blazor Client Application
-FROM mcr.microsoft.com/dotnet/sdk:10.0-rc.1 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Install Python for AOT compilation

--- a/src/CleanAspire.WebApp/Dockerfile
+++ b/src/CleanAspire.WebApp/Dockerfile
@@ -1,7 +1,7 @@
 # See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 # This stage is used to build the service project
-FROM mcr.microsoft.com/dotnet/sdk:10.0-rc.1 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 COPY ["src/CleanAspire.WebApp/CleanAspire.WebApp.csproj", "src/CleanAspire.WebApp/"]
@@ -18,7 +18,7 @@ ARG BUILD_CONFIGURATION=Release
 RUN dotnet publish "./CleanAspire.WebApp.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 # This stage is used in production or when running from VS in regular mode (Default when not using the Debug configuration)
-FROM mcr.microsoft.com/dotnet/aspnet:10.0-rc.1 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 


### PR DESCRIPTION
## Summary
- update the API, WebApp, and ClientApp Dockerfiles to build against the stable .NET 10 SDK/runtime images
- refresh the README messaging to highlight .NET 10 support while noting .NET 9 compatibility

## Testing
- ❌ `dotnet --version` *(not run: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0d8a69718832585da13ade5c15192