### PR TITLE
Tighten password policy and update UI inputs

### DIFF
--- a/src/CleanAspire.Api/Program.cs
+++ b/src/CleanAspire.Api/Program.cs
@@ -60,6 +60,11 @@ builder.Services.AddIdentityCore<ApplicationUser>(options =>
 {
     options.SignIn.RequireConfirmedEmail = true;
     options.Stores.SchemaVersion = IdentitySchemaVersions.Version3;
+    options.Password.RequireNonAlphanumeric = true;
+    options.Password.RequireDigit = true;
+    options.Password.RequireLowercase = true;
+    options.Password.RequireUppercase = true;
+    options.Password.RequiredLength = 8;
 })
     .AddEntityFrameworkStores<ApplicationDbContext>()
     .AddApiEndpoints();

--- a/src/CleanAspire.ClientApp/Components/PasswordInput.razor
+++ b/src/CleanAspire.ClientApp/Components/PasswordInput.razor
@@ -9,6 +9,7 @@ Label="@Label"
 Placeholder="@Placeholder"
 Required="true"
 RequiredError="@RequiredError"
+Immediate="@Immediate"
 Adornment="Adornment.End"
 AdornmentIcon="@AdornmentIcon"
 OnAdornmentClick="ToggleVisibility"
@@ -21,6 +22,7 @@ AdornmentAriaLabel="Show Password">
     [Parameter] public string? Label { get; set; }
     [Parameter] public string? Placeholder { get; set; }
     [Parameter] public string? RequiredError { get; set; }
+    [Parameter] public bool Immediate { get; set; } = true;
     [Parameter] public Expression<Func<string>>? Field { get; set; }
     [Parameter] public string Value { get; set; } = string.Empty;
     [Parameter] public EventCallback<string> ValueChanged { get; set; }

--- a/src/CleanAspire.ClientApp/Pages/Account/SignUp.razor
+++ b/src/CleanAspire.ClientApp/Pages/Account/SignUp.razor
@@ -25,7 +25,7 @@
                 @bind-Value="@model.Tenant">
 
                 </MultiTenantAutocomplete>
-                <MudTextField @bind-Value="model.Email" For="@(() => model.Email)" Label="@L["Email"]" Placeholder="@L["Email"]" Required="true" RequiredError="@L["Email is required"]"></MudTextField>
+                <MudTextField @bind-Value="model.Email" For="@(() => model.Email)" Label="@L["Email"]" Placeholder="@L["Email"]" Required="true" RequiredError="@L["Email is required"]" Immediate="true"></MudTextField>
                 <MudTextField @bind-Value="model.Nickname" For="@(() => model.Nickname)" Label="@L["Nickname"]" Placeholder="Nickname"></MudTextField>
                 <PasswordInput Field="@(() => model.Password)" @bind-Value="@model.Password"  Label="@L["Password"]" Placeholder="@L["Password"]" RequiredError="@L["Password is required"]" />
                 <PasswordInput Field="@(() => model.ConfirmPassword)" @bind-Value="@model.ConfirmPassword" Label="@L["Confirm password"]" Placeholder="@L["Confirm password"]" RequiredError="@L["Confirm password is required"]" />
@@ -83,8 +83,8 @@
         [EmailAddress]
         public string Email { get; set; } = string.Empty;
         [Required]
-        [StringLength(30, ErrorMessage = "Password must be at least 6 characters long.", MinimumLength = 6)]
-        [RegularExpression(@"^(?=.*[A-Za-z])(?=.*\d)(?=.*[\W_]).{6,}$", ErrorMessage = "Password must be at least 6 characters long and contain at least one letter, one number, and one special character.")]
+        [StringLength(30, ErrorMessage = "Password must be at least 8 characters long.", MinimumLength = 6)]
+        [RegularExpression(@"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_]).{8,}$", ErrorMessage = "Password must be at least 8 characters long and contain at least one letter, one number, and one special character.")]
         public string Password { get; set; } = string.Empty;
         [Required]
         [Compare(nameof(Password))]


### PR DESCRIPTION
Server: strengthen Identity password rules (require non-alphanumeric, digit, lowercase, uppercase, minimum length 8). Client: add Immediate parameter to PasswordInput (default true) and enable Immediate on the Email field. Update SignUp page password validation regex and error messages to enforce mixed-case, digit and special-char requirements and an 8-character minimum.